### PR TITLE
Auto aliases config

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -6,7 +6,7 @@ import * as luis from './adapters/luis';
 import * as rasa from './adapters/rasa';
 import * as snips from './adapters/snips';
 import * as web from './adapters/web';
-import { config, VALID_DISTRIBUTIONS } from './main';
+import { config, VALID_AUTO_ALIASES, VALID_DISTRIBUTIONS } from './main';
 import * as utils from './utils';
 
 // tslint:disable-next-line:no-var-requires
@@ -127,6 +127,25 @@ const adapterAccumulator = (format: IValidFormat, outputPath: string, formatOpti
     };
 };
 
+const validateArgs = () => {
+    if (argv.defaultDistribution) {
+        if (VALID_DISTRIBUTIONS.includes(argv.defaultDistribution)) {
+            config.defaultDistribution = argv.defaultDistribution;
+        } else {
+            throw new Error(
+                `Unknow defaultDistribution value: '${argv.defaultDistribution}'. Valid values are: ${VALID_DISTRIBUTIONS.join(', ')}.`
+            );
+        }
+    }
+    if (argv.autoAliases) {
+        if (VALID_AUTO_ALIASES.includes(argv.autoAliases)) {
+            config.autoAliases = argv.autoAliases;
+        } else {
+            throw new Error(`Unknow autoAliases value: '${argv.autoAliases}'. Valid values are: ${VALID_AUTO_ALIASES.join(', ')}.`);
+        }
+    }
+};
+
 (async () => {
     if (!argv._ || !argv._.length) {
         logger.error('Invalid chatito file.');
@@ -139,11 +158,9 @@ const adapterAccumulator = (format: IValidFormat, outputPath: string, formatOpti
         process.exit(1);
     }
     const outputPath = argv.outputPath || process.cwd();
-    if (argv.defaultDistribution && VALID_DISTRIBUTIONS.indexOf(argv.defaultDistribution) !== -1) {
-        config.defaultDistribution = argv.defaultDistribution;
-    }
-    logger.log(`NOTE: Using ${config.defaultDistribution} as default frequency distribution.`);
     try {
+        validateArgs();
+        logger.log(`NOTE: Using ${config.defaultDistribution} as default frequency distribution.`);
         // parse the formatOptions argument
         let formatOptions = null;
         if (argv.formatOptions) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,15 +13,18 @@ import {
 const logger = console;
 
 export const VALID_DISTRIBUTIONS = ['regular', 'even'] as const;
+export const VALID_AUTO_ALIASES = ['allow', 'warn', 'restrict'] as const;
 
 export interface IConfigOptions {
     defaultDistribution?: typeof VALID_DISTRIBUTIONS[number];
+    autoAliases: typeof VALID_AUTO_ALIASES[number];
 }
 
 type Configuration = Required<IConfigOptions>;
 
 export const config: Configuration = {
-    defaultDistribution: 'regular'
+    defaultDistribution: 'regular',
+    autoAliases: 'allow'
 };
 
 // tslint:disable-next-line:no-var-requires
@@ -531,6 +534,10 @@ const addMissingAliases = (defs: IEntities) => {
     }
     for (const alias of aliases) {
         if (!defs.Alias[alias]) {
+            if (config.autoAliases === 'warn') {
+                // tslint:disable-next-line: no-console
+                console.warn(`WARNING! Auto alias creation: '${alias}'`);
+            }
             defs.Alias[alias] = {
                 inner: [{ sentence: [{ value: alias, type: 'Text' }], probability: null }],
                 key: alias,
@@ -607,7 +614,9 @@ export const definitionsFromAST = (initialAst: IChatitoEntityAST[], importHandle
         }
         entity[odKey] = od;
     });
-    addMissingAliases(operatorDefinitions);
+    if (config.autoAliases !== 'restrict') {
+        addMissingAliases(operatorDefinitions);
+    }
     preCalcCardinality(operatorDefinitions);
     return operatorDefinitions;
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,9 +15,12 @@ const logger = console;
 export const VALID_DISTRIBUTIONS = ['regular', 'even'] as const;
 export const VALID_AUTO_ALIASES = ['allow', 'warn', 'restrict'] as const;
 
+export type distributionType = typeof VALID_DISTRIBUTIONS[number];
+export type autoAliasesType = typeof VALID_AUTO_ALIASES[number];
+
 export interface IConfigOptions {
-    defaultDistribution?: typeof VALID_DISTRIBUTIONS[number];
-    autoAliases: typeof VALID_AUTO_ALIASES[number];
+    defaultDistribution?: distributionType;
+    autoAliases?: autoAliasesType;
 }
 
 type Configuration = Required<IConfigOptions>;


### PR DESCRIPTION
Added autoAliases to configuration.
Valid options are 'allow' (default), 'warn' and 'restrict'

Now that we can import other chatito files it is very easy to use some aliases from another file but forget to import that file which leads to alias content not being picked up.

We can use --autoAliases=warn to get warnings about auto-created aliases to check if it's ok.
Or even use --autoAliases=restrict to disable the automatic aliases creation. In this case we'll get an error for any alias that is not defined.