### PR TITLE
Fix broken snips-nlu training because of missing keys

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    pathPrefix: '/Chatito',
+    pathPrefix: '/editor/chatito',
     siteMetadata: {
         title: 'Chatito'
     },

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "homepage": "https://github.com/rodrigopivi/Chatito",
   "dependencies": {
     "chance": "1.1.0",
+    "express": "^4.17.1",
     "minimist": "1.2.0"
   },
   "jest": {

--- a/pm2.json
+++ b/pm2.json
@@ -1,0 +1,7 @@
+{
+  "name": "Chatito Editor Express Web Server",
+  "script": "server.js",
+  "exec_interpreter": "node",
+  "exec_mode": "cluster",
+  "cwd": "/opt/chatito/"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,9 @@
+const express = require('express');
+
+const app = express();
+
+app.use(express.static('./public'));
+
+app.use('/editor/chatito', express.static('./public'));
+
+app.listen(8324);

--- a/src/adapters/snips.ts
+++ b/src/adapters/snips.ts
@@ -90,6 +90,11 @@ export async function adapter(dsl: string, formatOptions?: any, importer?: gen.I
             if (!training.entities[slotKey]) {
                 training.entities[slotKey] = {};
             }
+            training.entities[slotKey].use_synonyms = true;
+            training.entities[slotKey].automatically_extensible = true;
+            if (!training.entities[slotKey].data) {
+                training.entities[slotKey].data = [];
+            }
             return;
         }
         Object.keys(synonymsForSlots[slotKey]).forEach(synonymsValue => {

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -19,6 +19,7 @@ export default class Index extends React.Component<{}, {}> {
                     <link rel="mask-icon" href={`${__PATH_PREFIX__}/safari-pinned-tab.svg`} color="#5bbad5" />
                     <meta name="msapplication-TileColor" content="#da532c" />
                     <meta name="theme-color" content="#ffffff" />
+                    <base href={`/editor/chatito/`} />
                     <title>Chatito DSL - Generate dataset for chatbots</title>
                     <meta
                         name="keywords"


### PR DESCRIPTION
I was trying to train a snips dataset generated by chatito while an error arose. There was a missing key Exception. 

These missing keys are not set to default values when there are no synonyms for the entity. This PR fix this problem.